### PR TITLE
omit node-modules when start py-tests

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,3 @@
 [pytest]
 DJANGO_SETTINGS_MODULE=dynamis.settings
+norecursedirs  = node_modules


### PR DESCRIPTION
[pivotal-tracker-story](put-the-link-here)
### What was wrong
### How was it fixed
#### Cute animal picture
