### PR TITLE
Fix 219

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -1098,7 +1098,7 @@ Get list of items that need to be reviewed (by you).
                         }
                     }
                 ]
-f            }
+            }
 
 ## DEPRECATED: Peer Review History [/api/v1/application/peer-review-history]
 

--- a/apiary.apib
+++ b/apiary.apib
@@ -285,6 +285,7 @@ Please see this [Wiki for more information on tokens](https://github.com/dynamis
             
 ### Send ETH to buy Immature Tokens [POST /api/v1/accounts/{accountid}/immature_tokens/buy]
 
+**IMPORTANT** - you have to call this request before send real transaction
 When user clicks on 'Send transaction' or 'Buy' button.
 Please see this [Wiki for more information on tokens](https://github.com/dynamisdao/dynamisapp/wiki/RiskAssessment-tokens-(DYNA))
 
@@ -752,6 +753,7 @@ When policy is at least in **POLICY_STATUS_SUBMITTED**, this method will return 
 
 ### Send SmartDeposit [POST /api/v1/policies/{policyid}/smart_deposit/send]
 
+**IMPORTANT** - you have to call this request before send real transaction
 When user clicks on 'Send transaction' button -> we need to move smart deposit into 'waiting' state and wait for transaction confirmation.
 
 + Request 
@@ -1096,7 +1098,7 @@ Get list of items that need to be reviewed (by you).
                         }
                     }
                 ]
-            }
+f            }
 
 ## DEPRECATED: Peer Review History [/api/v1/application/peer-review-history]
 

--- a/dynamis/apps/payments/business_logic.py
+++ b/dynamis/apps/payments/business_logic.py
@@ -2,6 +2,8 @@ import json
 
 import requests
 import time
+
+from django.db.transaction import atomic
 from django.utils import timezone
 from constance import config
 from requests import ConnectionError
@@ -30,6 +32,7 @@ def refresh_usd_eth_exchange_rate():
     config.DOLLAR_ETH_EXCHANGE_RATE = round(float(response_json[0]['price_usd']), 3)
 
 
+@atomic
 def check_transfers_change_model_states(wait_tx_model):
     if wait_tx_model.state == wait_tx_model.WAIT_FOR_TX_STATUS_WAITING:
         eth_tx = None

--- a/dynamis/core/permissions.py
+++ b/dynamis/core/permissions.py
@@ -17,3 +17,11 @@ class IsAdminOrPolicyOwnerPermission(permissions.BasePermission):
             return False
         if request.user.is_admin or obj.policy.user == request.user:
             return True
+
+
+class IsRiskAssessorPermission(permissions.BasePermission):
+    message = 'Access not allowed.'
+
+    def has_object_permission(self, request, view, obj):
+        if request.user.is_authenticated() and request.user.is_risk_assessor:
+            return True


### PR DESCRIPTION
add assessor's permissions to all immature token requests, extend tests. Add atomic db-transactions to create eth-tx functions
